### PR TITLE
AccessToken 재발급 API 개발

### DIFF
--- a/joljak-application/src/main/java/kr/joljak/api/auth/controller/AuthController.java
+++ b/joljak-application/src/main/java/kr/joljak/api/auth/controller/AuthController.java
@@ -6,11 +6,13 @@ import kr.joljak.api.auth.request.SignUpRequest;
 import kr.joljak.api.auth.response.SignInResponse;
 import kr.joljak.api.auth.service.AuthService;
 
+import kr.joljak.core.jwt.AccessToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,5 +36,12 @@ public class AuthController {
   @ResponseStatus(HttpStatus.OK)
   public SignInResponse signIn(@RequestBody SignInRequest signInRequest) {
     return authService.signIn(signInRequest);
+  }
+
+  @ApiOperation("AccessToken 재발급")
+  @PostMapping("/reissue/accesstoken")
+  @ResponseStatus(HttpStatus.OK)
+  public AccessToken reissueAccessToken(@RequestHeader String refreshToken) {
+    return authService.reissueAccessToken(refreshToken);
   }
 }

--- a/joljak-application/src/main/java/kr/joljak/api/auth/service/AuthService.java
+++ b/joljak-application/src/main/java/kr/joljak/api/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import kr.joljak.api.auth.request.SignInRequest;
 import kr.joljak.api.auth.request.SignUpRequest;
 import kr.joljak.api.auth.response.SignInResponse;
 import kr.joljak.core.jwt.AccessToken;
+import kr.joljak.core.jwt.JwtToken;
 import kr.joljak.core.jwt.JwtTokenProvider;
 import kr.joljak.core.security.UserRole;
 import kr.joljak.domain.invite.service.InviteService;
@@ -42,6 +43,13 @@ public class AuthService {
     }
 
     return getSignInResponse(SimpleUser.of(user));
+  }
+
+  public AccessToken reissueAccessToken(String refreshToken) {
+    String classOf = jwtTokenProvider.getClassOfByToken(refreshToken, JwtToken.REFRESH_TOKEN);
+    List<String> roles = jwtTokenProvider.getRolesByToken(refreshToken, JwtToken.REFRESH_TOKEN);
+
+    return jwtTokenProvider.generateAccessToken(classOf, roles);
   }
 
   private SignInResponse getSignInResponse(SimpleUser simpleUser) {

--- a/joljak-application/src/test/java/kr/joljak/api/auth/ReissueAccessToken.java
+++ b/joljak-application/src/test/java/kr/joljak/api/auth/ReissueAccessToken.java
@@ -1,0 +1,60 @@
+package kr.joljak.api.auth;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import kr.joljak.api.common.CommonApiTest;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+public class ReissueAccessToken extends CommonApiTest {
+
+  @Test
+  public void reissueAccessToken_Success() throws Exception {
+    // given
+    String refreshToken = getUserRefreshToken();
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+      post(AUTH_URL + "/reissue/accesstoken")
+        .header("refreshToken", refreshToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+    ).andReturn();
+
+    //then
+    assertEquals(200, mvcResult.getResponse().getStatus());
+  }
+
+  @Test
+  public void reissueAccessToken_Fail_IsNotRefreshToken() throws Exception {
+    // given
+    String refreshToken = getUserAccessToken();
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+        post(AUTH_URL + "/reissue/accesstoken")
+            .header("refreshToken", refreshToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+    ).andReturn();
+
+    //then
+    assertEquals(401, mvcResult.getResponse().getStatus());
+  }
+
+  @Test
+  public void reissueAccessToken_Fail_InvalidToekn() throws Exception {
+    // given
+    String refreshToken = getUserAccessToken() + nextId++;
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+        post(AUTH_URL + "/reissue/accesstoken")
+            .header("refreshToken", refreshToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+    ).andReturn();
+
+    //then
+    assertEquals(401, mvcResult.getResponse().getStatus());
+  }
+}

--- a/joljak-application/src/test/java/kr/joljak/api/auth/SignInTest.java
+++ b/joljak-application/src/test/java/kr/joljak/api/auth/SignInTest.java
@@ -54,9 +54,9 @@ public class SignInTest extends CommonApiTest {
 
     //when
     MvcResult mvcResult = mockMvc.perform(
-        post(AUTH_URL + "/signin")
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .content(request)
+      post(AUTH_URL + "/signin")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(request)
     ).andReturn();
 
     //then

--- a/joljak-core/src/main/java/kr/joljak/core/jwt/JwtTokenProvider.java
+++ b/joljak-core/src/main/java/kr/joljak/core/jwt/JwtTokenProvider.java
@@ -28,12 +28,14 @@ public class JwtTokenProvider {
 
   private static final String CLASS_OF = "classOf";
   private static final String ROLES = "roles";
+  private static final String ISSUER = "kr.joljak";
 
   public AccessToken generateAccessToken(String classOf, List<String> roles) {
     Date now = new Date();
     Date expireDate = new Date(now.getTime() + expirationTime);
 
     String token = Jwts.builder()
+      .setIssuer(ISSUER)
       .setClaims(createDefaultClaims(classOf, roles))
       .setSubject(JwtToken.ACCESS_TOKEN.getName())
       .setIssuedAt(now)
@@ -47,7 +49,7 @@ public class JwtTokenProvider {
   public String generateRefreshToken(String classOf, List<String> roles) {
 
     return Jwts.builder()
-      .setHeaderParam("typ", "JWT")
+      .setIssuer(ISSUER)
       .setClaims(createDefaultClaims(classOf, roles))
       .setSubject(JwtToken.REFRESH_TOKEN.getName())
       .setIssuedAt(new Date())
@@ -63,13 +65,22 @@ public class JwtTokenProvider {
     return claims;
   }
 
-  public Long getClassOfByToken(String token, JwtToken jwtToken){
+  public String getClassOfByToken(String token, JwtToken jwtToken){
     Claims claims = decodingToken(token);
 
     if(!(claims.getSubject().equals(jwtToken.getName())))
       throw new InvalidTokenException("token subject do not match.");
 
-    return Long.parseLong(claims.get(CLASS_OF).toString());
+    return claims.get(CLASS_OF).toString();
+  }
+
+  public List<String> getRolesByToken(String token, JwtToken jwtToken){
+    Claims claims = decodingToken(token);
+
+    if(!(claims.getSubject().equals(jwtToken.getName())))
+      throw new InvalidTokenException("token subject do not match.");
+
+    return claims.get(ROLES, List.class);
   }
 
   public Authentication getAuthentication(String token) {

--- a/joljak-domain-rds/src/test/java/kr/joljak/domain/user/UserServiceTest.java
+++ b/joljak-domain-rds/src/test/java/kr/joljak/domain/user/UserServiceTest.java
@@ -1,12 +1,9 @@
 package kr.joljak.domain.user;
 
-import static org.junit.Assert.assertEquals;
-
 import kr.joljak.core.security.UserRole;
 import kr.joljak.domain.common.CommonDomainTest;
 import kr.joljak.domain.user.entity.User;
 import kr.joljak.domain.user.exception.AlreadyClassOfExistException;
-import kr.joljak.domain.user.exception.InvalidPasswordException;
 import kr.joljak.domain.user.exception.UserNotFoundException;
 import kr.joljak.domain.user.service.UserService;
 import org.assertj.core.api.Assertions;
@@ -39,7 +36,7 @@ public class UserServiceTest extends CommonDomainTest {
   }
 
   @Test
-  public void checkDuplicateClassOf_Success_NotDuplicate() {
+  public void checkDuplicateClassOf_Success_AlreadyClassOfExistException() {
     // given
     String successClass = "successClass";
 


### PR DESCRIPTION
## 작업 내용(구체적으로)
- AccessToken 재발급(refreshToken 이용)
- 토큰 값으로부터 유저 역할 획득하는 로직 개발(JwtTokenProvider)
- 테스트 코드 작성
- 여타 코드중 indent 수정

## Api
- [x] AccessToken 재발급 API


## Test Result(테스트 결과 이미지 첨부)
![스크린샷 2021-03-06 오후 5 06 22](https://user-images.githubusercontent.com/50758600/110199963-91253780-7e9e-11eb-9900-8fb53e0c69a5.png)

- [x] AccessToken 재발급_성공
- [x] AccessToken 재발급_실패_잘못된 토큰 subject
- [x] AccessToken 재발급_실패_유효하지않은 토큰값  