### PR TITLE
연락처 업데이트 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ subprojects {
 
     dependencies {
         implementation("org.springframework.boot:spring-boot-starter-web")
+        implementation("org.springframework.boot:spring-boot-starter-security")
 
         testImplementation('org.springframework.boot:spring-boot-starter-test')
         testImplementation group: 'junit', name: 'junit', version: "${junitVersion}"
@@ -65,7 +66,6 @@ project(':joljak-application') {
         implementation("io.springfox:springfox-swagger-ui:${swaggerVersion}")
         implementation("io.springfox:springfox-spring-web:${swaggerVersion}")
         implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-        implementation("org.springframework.boot:spring-boot-starter-security")
         implementation("com.h2database:h2")
 
         testImplementation('org.springframework.security:spring-security-test')
@@ -81,6 +81,7 @@ project(':joljak-domain-rds') {
     jar { enabled = true }
     dependencies {
         implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+        testImplementation('org.springframework.security:spring-security-test')
 
         runtime('com.h2database:h2')
 
@@ -93,7 +94,6 @@ project(':joljak-core') {
     bootJar { enabled = false }
     jar { enabled = true }
     dependencies {
-        implementation("org.springframework.boot:spring-boot-starter-security")
         implementation("io.jsonwebtoken:jjwt-api:${jjwtVersion}")
         implementation("io.jsonwebtoken:jjwt:0.9.1")
 

--- a/joljak-application/src/main/java/kr/joljak/api/config/SecurityConfig.java
+++ b/joljak-application/src/main/java/kr/joljak/api/config/SecurityConfig.java
@@ -47,12 +47,16 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .and()
         .authorizeRequests()
         .mvcMatchers(
-            "/", "/csrf", "/v2/api-docs", "/swagger-resources/**",
-            "/swagger-ui/**", "/webjars/**", "/swagger/**", "/swagger-ui.html", "/swagger-ui.html/**",
-            "/configuration/**"
+          "/", "/csrf", "/v2/api-docs", "/swagger-resources/**",
+          "/swagger-ui/**", "/webjars/**", "/swagger/**", "/swagger-ui.html", "/swagger-ui.html/**",
+          "/configuration/**"
         ).permitAll()
-        .antMatchers("/api/v1/users/**").permitAll()
-        .antMatchers("/api/v1/invites/**").hasRole(UserRole.ADMIN.getKey())
+        .antMatchers(
+          "/api/v1/auth/signup", "/api/v1/auth/signin", "/api/v1/auth/reissue/accesstoken"
+        ).permitAll()
+        .antMatchers(
+          "/api/v1/invites/**"
+        ).hasRole(UserRole.ADMIN.getKey())
         .anyRequest().authenticated()
 
         .and()
@@ -64,8 +68,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     web.ignoring()
       .antMatchers(HttpMethod.OPTIONS, "/**")
       .antMatchers(
-        "/",
-        "/h2-console/**"
+        "/", "/h2-console/**"
       );
   }
 

--- a/joljak-application/src/main/java/kr/joljak/api/user/controller/UserController.java
+++ b/joljak-application/src/main/java/kr/joljak/api/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package kr.joljak.api.user.controller;
+
+import io.swagger.annotations.ApiOperation;
+import kr.joljak.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+  private final UserService userService;
+
+  @ApiOperation("유저 휴대폰 번호 업데이트")
+  @PatchMapping("/{classOf}/phonenumber")
+  @ResponseStatus(HttpStatus.OK)
+  public void updatePhoneNumber(@PathVariable String classOf, @RequestBody String phoneNumber) {
+    userService.updatePhoneNumber(classOf, phoneNumber);
+  }
+
+  @ApiOperation("유저 인스타 아이디 업데이트")
+  @PatchMapping("/{classOf}/istagramid")
+  @ResponseStatus(HttpStatus.OK)
+  public void updateInstagramId(@PathVariable String classOf, @RequestBody String instagramId) {
+    userService.updateInstagramId(classOf, instagramId);
+  }
+
+  @ApiOperation("유저 카카오 아이디 업데이트")
+  @PatchMapping("/{classOf}/kakaoid")
+  @ResponseStatus(HttpStatus.OK)
+  public void updateKakaoId(@PathVariable String classOf, @RequestBody String kakaoId) {
+    userService.updateKakaoId(classOf, kakaoId);
+  }
+}

--- a/joljak-application/src/test/java/kr/joljak/api/auth/ReissueAccessTokenTest.java
+++ b/joljak-application/src/test/java/kr/joljak/api/auth/ReissueAccessTokenTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 
-public class ReissueAccessToken extends CommonApiTest {
+public class ReissueAccessTokenTest extends CommonApiTest {
 
   @Test
   public void reissueAccessToken_Success() throws Exception {

--- a/joljak-application/src/test/java/kr/joljak/api/common/CommonApiTest.java
+++ b/joljak-application/src/test/java/kr/joljak/api/common/CommonApiTest.java
@@ -10,6 +10,7 @@ import kr.joljak.domain.invite.entity.Invite;
 import kr.joljak.domain.invite.repository.InviteRepository;
 import kr.joljak.domain.user.entity.User;
 import kr.joljak.domain.user.entity.UserProjectRole;
+import kr.joljak.domain.user.exception.UserNotFoundException;
 import kr.joljak.domain.user.repository.UserRepository;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -34,8 +35,6 @@ public abstract class CommonApiTest {
   @Autowired
   private JwtTokenProvider jwtTokenProvider;
 
-  private User admin;
-  private User user;
   private String adminAccessToken;
   private String adminRefreshToken;
   private String userAccessToken;
@@ -50,9 +49,13 @@ public abstract class CommonApiTest {
 
   protected MockMvc mockMvc;
 
+  protected static final String TEST_ADMIN_CLASS_OF = "testUser0";
+  protected static final String TEST_USER_CLASS_OF = "testUser1";
+
   protected final String URL = "http://localhost:";
   protected final String AUTH_URL = URL + port + "/api/v1/auth";
   protected final String INVITE_URL = URL + port + "/api/v1/invites";
+  protected final String USER_URL = URL + port + "/api/v1/users";
 
   protected static int nextId = 0;
 
@@ -62,10 +65,10 @@ public abstract class CommonApiTest {
       .webAppContextSetup(webApplicationContext)
       .build();
 
-    admin = userRepository.save(createMockUser(UserRole.ADMIN));
+    User admin = userRepository.save(createMockUser(UserRole.ADMIN));
     setToken(admin, UserRole.ADMIN);
 
-    user = userRepository.save(createMockUser(UserRole.USER));
+    User user = userRepository.save(createMockUser(UserRole.USER));
     setToken(user, UserRole.USER);
   }
 
@@ -116,11 +119,16 @@ public abstract class CommonApiTest {
   }
 
   public User getAdmin() {
-    return admin;
+    return getUserByClassOf(TEST_USER_CLASS_OF);
   }
 
   public User getUser() {
-    return user;
+    return getUserByClassOf(TEST_ADMIN_CLASS_OF);
+  }
+
+  public User getUserByClassOf(String classOf) {
+    return userRepository.findByClassOf(classOf)
+        .orElseThrow(UserNotFoundException::new);
   }
 
   public String getAdminAccessToken() {

--- a/joljak-application/src/test/java/kr/joljak/api/user/UpdateInstagramIdTest.java
+++ b/joljak-application/src/test/java/kr/joljak/api/user/UpdateInstagramIdTest.java
@@ -1,0 +1,68 @@
+package kr.joljak.api.user;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.joljak.api.common.CommonApiTest;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+public class UpdateInstagramIdTest extends CommonApiTest {
+
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void updateInstagramId_Success() throws Exception {
+    // given
+    String instagramId = "instaId" + nextId++;
+    String request = new ObjectMapper().writeValueAsString(instagramId);
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+      patch(USER_URL + "/" + TEST_USER_CLASS_OF + "/istagramid")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(request)
+    ).andReturn();
+
+    //then
+    assertEquals(200, mvcResult.getResponse().getStatus());
+  }
+
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void updateInstagramId_Fail_UserDoesNotMatch() throws Exception {
+    // given
+    String instagramId = "instaId" + nextId++;
+    String request = new ObjectMapper().writeValueAsString(instagramId);
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+        patch(USER_URL + "/" + TEST_ADMIN_CLASS_OF + "/istagramid")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request)
+    ).andReturn();
+
+    //then
+    assertEquals(403, mvcResult.getResponse().getStatus());
+  }
+
+  @Test
+  @WithMockUser(username = "notFoundUser", roles = "USER")
+  public void updateInstagramId_Fail_UserNotFoundException() throws Exception {
+    // given
+    String instagramId = "instaId" + nextId++;
+    String request = new ObjectMapper().writeValueAsString(instagramId);
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+        patch(USER_URL + "/" + "notFoundUser" + "/istagramid")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request)
+    ).andReturn();
+
+    //then
+    assertEquals(404, mvcResult.getResponse().getStatus());
+  }
+}

--- a/joljak-application/src/test/java/kr/joljak/api/user/UpdateKakaoIdTest.java
+++ b/joljak-application/src/test/java/kr/joljak/api/user/UpdateKakaoIdTest.java
@@ -1,0 +1,68 @@
+package kr.joljak.api.user;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.joljak.api.common.CommonApiTest;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+public class UpdateKakaoIdTest extends CommonApiTest {
+
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void updateKakaoId_Success() throws Exception {
+    // given
+    String kakaoId = "kakaoId" + nextId++;
+    String request = new ObjectMapper().writeValueAsString(kakaoId);
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+      patch(USER_URL + "/" + TEST_USER_CLASS_OF + "/kakaoid")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(request)
+    ).andReturn();
+
+    //then
+    assertEquals(200, mvcResult.getResponse().getStatus());
+  }
+
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void updateKakaoId_Fail_UserDoesNotMatch() throws Exception {
+    // given
+    String kakaoId = "kakaoId" + nextId++;
+    String request = new ObjectMapper().writeValueAsString(kakaoId);
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+      patch(USER_URL + "/" + TEST_ADMIN_CLASS_OF + "/kakaoid")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(request)
+    ).andReturn();
+
+    //then
+    assertEquals(403, mvcResult.getResponse().getStatus());
+  }
+
+  @Test
+  @WithMockUser(username = "notFoundUser", roles = "USER")
+  public void updateKakaoId_Fail_UserNotFoundException() throws Exception {
+    // given
+    String phoneNumber = getUser().getPhoneNumber() + nextId++;
+    String request = new ObjectMapper().writeValueAsString(phoneNumber);
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+      patch(USER_URL + "/" + "notFoundUser" + "/kakaoid")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(request)
+    ).andReturn();
+
+    //then
+    assertEquals(404, mvcResult.getResponse().getStatus());
+  }
+}

--- a/joljak-application/src/test/java/kr/joljak/api/user/UpdatePhoneNumberTest.java
+++ b/joljak-application/src/test/java/kr/joljak/api/user/UpdatePhoneNumberTest.java
@@ -1,0 +1,68 @@
+package kr.joljak.api.user;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.joljak.api.common.CommonApiTest;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+public class UpdatePhoneNumberTest extends CommonApiTest {
+
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void updatePhoneNumber_Success() throws Exception {
+    // given
+    String phoneNumber = getUser().getPhoneNumber() + nextId++;
+    String request = new ObjectMapper().writeValueAsString(phoneNumber);
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+      patch(USER_URL + "/" + TEST_USER_CLASS_OF + "/phonenumber")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(request)
+    ).andReturn();
+
+    //then
+    assertEquals(200, mvcResult.getResponse().getStatus());
+  }
+
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void updatePhoneNumber_Fail_UserDoesNotMatch() throws Exception {
+    // given
+    String phoneNumber = getUser().getPhoneNumber() + nextId++;
+    String request = new ObjectMapper().writeValueAsString(phoneNumber);
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+      patch(USER_URL + "/" + TEST_ADMIN_CLASS_OF + "/phonenumber")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(request)
+    ).andReturn();
+
+    //then
+    assertEquals(403, mvcResult.getResponse().getStatus());
+  }
+
+  @Test
+  @WithMockUser(username = "notFoundUser", roles = "USER")
+  public void updatePhoneNumber_Fail_UserNotFoundException() throws Exception {
+    // given
+    String phoneNumber = getUser().getPhoneNumber() + nextId++;
+    String request = new ObjectMapper().writeValueAsString(phoneNumber);
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+      patch(USER_URL + "/" + "notFoundUser" + "/phonenumber")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(request)
+    ).andReturn();
+
+    //then
+    assertEquals(404, mvcResult.getResponse().getStatus());
+  }
+}

--- a/joljak-core/src/main/java/kr/joljak/core/security/AuthenticationUtils.java
+++ b/joljak-core/src/main/java/kr/joljak/core/security/AuthenticationUtils.java
@@ -1,0 +1,9 @@
+package kr.joljak.core.security;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class AuthenticationUtils {
+  public static String getClassOf() {
+    return SecurityContextHolder.getContext().getAuthentication().getName();
+  }
+}

--- a/joljak-domain-rds/src/main/java/kr/joljak/domain/user/entity/User.java
+++ b/joljak-domain-rds/src/main/java/kr/joljak/domain/user/entity/User.java
@@ -37,6 +37,9 @@ public class User extends ExtendEntity {
 
   @Column(nullable = false)
   private String phoneNumber;
+  private String instagramId;
+
+  private String kakaoId;
 
   @Column(nullable = false)
   @Enumerated(value = EnumType.STRING)
@@ -68,5 +71,13 @@ public class User extends ExtendEntity {
 
   public void setPhoneNumber(String phoneNumber) {
     this.phoneNumber = phoneNumber;
+  }
+
+  public void setInstagramId(String instagramId) {
+    this.instagramId = instagramId;
+  }
+
+  public void setKakaoId(String kakaoId) {
+    this.kakaoId = kakaoId;
   }
 }

--- a/joljak-domain-rds/src/main/java/kr/joljak/domain/user/service/UserService.java
+++ b/joljak-domain-rds/src/main/java/kr/joljak/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package kr.joljak.domain.user.service;
 
+import kr.joljak.core.jwt.PermissionException;
+import kr.joljak.core.security.AuthenticationUtils;
 import kr.joljak.domain.user.entity.User;
 import kr.joljak.domain.user.exception.AlreadyClassOfExistException;
 import kr.joljak.domain.user.exception.UserNotFoundException;
@@ -30,6 +32,48 @@ public class UserService {
     boolean isDuplicate = userRepository.existsByClassOf(classOf);
     if (isDuplicate) {
       throw new AlreadyClassOfExistException();
+    }
+  }
+
+  @Transactional
+  public void updatePhoneNumber(String classOf, String phoneNumber) {
+    validExistClassOf(classOf);
+    User user = userRepository.findByClassOf(classOf)
+      .orElseThrow(UserNotFoundException::new);
+
+    user.setPhoneNumber(phoneNumber);
+  }
+
+  @Transactional
+  public void updateInstagramId(String classOf, String instagramId) {
+    validExistClassOf(classOf);
+    User user = userRepository.findByClassOf(classOf)
+      .orElseThrow(UserNotFoundException::new);
+
+    user.setInstagramId(instagramId);
+  }
+
+  @Transactional
+  public void updateKakaoId(String classOf, String kakaoId) {
+    validExistClassOf(classOf);
+    User user = userRepository.findByClassOf(classOf)
+        .orElseThrow(UserNotFoundException::new);
+
+    user.setKakaoId(kakaoId);
+  }
+
+  public void validExistClassOf(String classOf) {
+    validAuthenticationClassOf(classOf);
+
+    if (!userRepository.existsByClassOf(classOf)) {
+      throw new UserNotFoundException();
+    }
+  }
+
+  public static void validAuthenticationClassOf(String classOf) {
+    String authenticationClassOf = AuthenticationUtils.getClassOf();
+    if (!classOf.equals(authenticationClassOf)) {
+      throw new PermissionException("User does not match");
     }
   }
 

--- a/joljak-domain-rds/src/test/java/kr/joljak/domain/common/CommonDomainTest.java
+++ b/joljak-domain-rds/src/test/java/kr/joljak/domain/common/CommonDomainTest.java
@@ -9,6 +9,7 @@ import kr.joljak.core.jwt.JwtTokenProvider;
 import kr.joljak.core.security.UserRole;
 import kr.joljak.domain.user.entity.User;
 import kr.joljak.domain.user.entity.UserProjectRole;
+import kr.joljak.domain.user.exception.UserNotFoundException;
 import kr.joljak.domain.user.repository.UserRepository;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -25,21 +26,22 @@ public abstract class CommonDomainTest {
   @Autowired
   private JwtTokenProvider jwtTokenProvider;
 
-  private User admin;
-  private User user;
   private AccessToken adminAccessToken;
   private String adminRefreshToken;
   private AccessToken userAccessToken;
   private String userRefreshToken;
 
+  public static final String TEST_ADMIN_CLASS_OF = "testUser0";
+  public static final String TEST_USER_CLASS_OF = "testUser1";
+
   protected static int nextId;
 
   @Before
   public void setup() {
-    admin = userRepository.save(createMockUser(UserRole.ADMIN));
+    User admin = userRepository.save(createMockUser(UserRole.ADMIN));
     setToken(admin, UserRole.ADMIN);
 
-    user = userRepository.save(createMockUser(UserRole.USER));
+    User user = userRepository.save(createMockUser(UserRole.USER));
     setToken(user, UserRole.USER);
   }
 
@@ -80,11 +82,16 @@ public abstract class CommonDomainTest {
   }
 
   public User getAdmin() {
-    return admin;
+    return getUserByClassOf(TEST_USER_CLASS_OF);
   }
 
   public User getUser() {
-    return user;
+    return getUserByClassOf(TEST_ADMIN_CLASS_OF);
+  }
+
+  public User getUserByClassOf(String classOf) {
+    return userRepository.findByClassOf(classOf)
+        .orElseThrow(UserNotFoundException::new);
   }
 
   public AccessToken getAdminAccessToken() {

--- a/joljak-domain-rds/src/test/java/kr/joljak/domain/user/UserServiceTest.java
+++ b/joljak-domain-rds/src/test/java/kr/joljak/domain/user/UserServiceTest.java
@@ -1,5 +1,7 @@
 package kr.joljak.domain.user;
 
+import static org.junit.Assert.assertEquals;
+
 import kr.joljak.core.security.UserRole;
 import kr.joljak.domain.common.CommonDomainTest;
 import kr.joljak.domain.user.entity.User;
@@ -9,8 +11,10 @@ import kr.joljak.domain.user.service.UserService;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
 
 public class UserServiceTest extends CommonDomainTest {
+
   @Autowired
   private UserService userService;
 
@@ -76,4 +80,48 @@ public class UserServiceTest extends CommonDomainTest {
     // then
   }
 
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void updatePhoneNumber_success() {
+    // given
+    User user = userService.getUserByClassOf(TEST_USER_CLASS_OF);
+    String changePhoneNumber = user.getPhoneNumber() + nextId++;
+
+    // when
+    userService.updatePhoneNumber(user.getClassOf(), changePhoneNumber);
+    user = userService.getUserByClassOf(user.getClassOf());
+
+    // then
+    assertEquals(user.getPhoneNumber(), changePhoneNumber);
+  }
+
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void updateInstagramId_success() {
+    // given
+    User user = userService.getUserByClassOf(TEST_USER_CLASS_OF);
+    String changeInstagramId = "changeInstagramId" + nextId++;
+
+    // when
+    userService.updateInstagramId(user.getClassOf(), changeInstagramId);
+    user = userService.getUserByClassOf(user.getClassOf());
+
+    // then
+    assertEquals(user.getInstagramId(), changeInstagramId);
+  }
+
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void updateKakaoId_success() {
+    // given
+    User user = userService.getUserByClassOf(TEST_USER_CLASS_OF);
+    String changeKakaoId = "changeKakaoId" + nextId++;
+
+    // when
+    userService.updateKakaoId(user.getClassOf(), changeKakaoId);
+    user = userService.getUserByClassOf(user.getClassOf());
+
+    // then
+    assertEquals(user.getKakaoId(), changeKakaoId);
+  }
 }


### PR DESCRIPTION

## 작업 내용(구체적으로)
- 인스타 아이디 업데이트 API
- 휴대폰 번호 업데이트 API
- 카카오 아이디 업데이트 API
- @WithMockUser 사용을 위해 CommonApiTest, CommonDomainTest 코드 일부 수정
- 실제 유저 정보를 확인하기 위한 작업을 위해 AuthenticationUtils 개발
- 일부 코드 스타일 변경

## Setting
- [x] spring security dependency를 모든 프로젝트에 적용


## Enity
- [x] User Entity에 인스타와 카카오 아이디 멤버값 추가

## Api
- [x] 인스타 아이디 업데이트 API
- [x] 휴대폰 번호 업데이트 API
- [x] 카카오 아이디 업데이트 API

## Test Result(테스트 결과 이미지 첨부)

### API(Application)
- 인스타 아이디 업데이트 API
  ![스크린샷 2021-03-07 오후 12 00 14](https://user-images.githubusercontent.com/50758600/110227535-b8cadd00-7f3c-11eb-9e4a-ce216f7e49a3.png)
  - 인스타 아이디 업데이트 _ 성공
  - 인스타 아이디 업데이트 _ 실패 _ 토큰 정보 불일치
  - 인스타 아이디 업데이트 _ 실패 _ 유저 정보 없음
  
- 휴대폰 번호 업데이트 API
  ![스크린샷 2021-03-07 오후 12 01 19](https://user-images.githubusercontent.com/50758600/110227554-dbf58c80-7f3c-11eb-8b30-411c433f4224.png)
  - 휴대폰 번호 업데이트 _ 성공
  - 휴대폰 번호 업데이트 _ 실패 _ 토큰 정보 불일치
  - 휴대폰 번호 업데이트 _ 실패 _ 유저 정보 없음
  
- 카카오 아이디 업데이트 API
  ![스크린샷 2021-03-07 오후 12 02 03](https://user-images.githubusercontent.com/50758600/110227561-f465a700-7f3c-11eb-8887-7544b36809ad.png)
  - 카카오 아이디 업데이트 _ 성공
  - 카카오 아이디 업데이트 _ 실패 _ 토큰 정보 불일치
  - 카카오 아이디 업데이트 _ 실패 _ 유저 정보 없음

### Service(Domain)
![스크린샷 2021-03-07 오후 12 03 45](https://user-images.githubusercontent.com/50758600/110227596-4dcdd600-7f3d-11eb-9b3d-5dc2857b38e6.png)
- 휴대폰 번호 업데이트 _ 성공
- 카카오 아이디 업데이트 _ 성공
- 인스타 아이디 업데이트 _ 성공

실패건에 대해서는 getUserByClassOf_Fail_UserNotFoundException 메소드에서 이미 진행되고 있기 때문에 테스트 코드를 더 이상 작성하지 않았음.
