### PR TITLE
마이 페이지 API

### DIFF
--- a/joljak-application/src/main/java/kr/joljak/api/user/controller/UserController.java
+++ b/joljak-application/src/main/java/kr/joljak/api/user/controller/UserController.java
@@ -1,9 +1,12 @@
 package kr.joljak.api.user.controller;
 
 import io.swagger.annotations.ApiOperation;
+import kr.joljak.api.user.response.MyPageResponse;
+import kr.joljak.domain.user.dto.SimpleUser;
 import kr.joljak.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,5 +39,16 @@ public class UserController {
   @ResponseStatus(HttpStatus.OK)
   public void updateKakaoId(@PathVariable String classOf, @RequestBody String kakaoId) {
     userService.updateKakaoId(classOf, kakaoId);
+  }
+
+  @ApiOperation("마이페이지 API")
+  @GetMapping("/{classOf}")
+  @ResponseStatus(HttpStatus.OK)
+  public MyPageResponse myPage(@PathVariable String classOf) {
+    SimpleUser user = userService.getMyPage(classOf);
+
+    return MyPageResponse.builder()
+      .user(user)
+      .build();
   }
 }

--- a/joljak-application/src/main/java/kr/joljak/api/user/response/MyPageResponse.java
+++ b/joljak-application/src/main/java/kr/joljak/api/user/response/MyPageResponse.java
@@ -1,0 +1,18 @@
+package kr.joljak.api.user.response;
+
+import kr.joljak.domain.user.dto.SimpleUser;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyPageResponse {
+  private SimpleUser user;
+
+  @Builder
+  public MyPageResponse(SimpleUser user) {
+    this.user = user;
+  }
+}

--- a/joljak-application/src/test/java/kr/joljak/api/user/MyPageTest.java
+++ b/joljak-application/src/test/java/kr/joljak/api/user/MyPageTest.java
@@ -21,7 +21,33 @@ public class MyPageTest extends CommonApiTest {
     ).andReturn();
 
     //then
-    System.out.println(mvcResult.getResponse().getErrorMessage());
     assertEquals(200, mvcResult.getResponse().getStatus());
+  }
+
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void myPage_Fail_UserDoesNotMatch() throws Exception {
+    //given, when
+    MvcResult mvcResult = mockMvc.perform(
+        get(USER_URL + "/" + TEST_ADMIN_CLASS_OF)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+    ).andReturn();
+
+    //then
+    System.out.println(mvcResult.getResponse().getErrorMessage());
+    assertEquals(403, mvcResult.getResponse().getStatus());
+  }
+
+  @Test
+  @WithMockUser(username = "notFoundUser", roles = "USER")
+  public void myPage_Fail_NotFoundUser() throws Exception {
+    //given, when
+    MvcResult mvcResult = mockMvc.perform(
+        get(USER_URL + "/" + "notFoundUser")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+    ).andReturn();
+
+    //then
+    assertEquals(404, mvcResult.getResponse().getStatus());
   }
 }

--- a/joljak-application/src/test/java/kr/joljak/api/user/MyPageTest.java
+++ b/joljak-application/src/test/java/kr/joljak/api/user/MyPageTest.java
@@ -29,8 +29,8 @@ public class MyPageTest extends CommonApiTest {
   public void myPage_Fail_UserDoesNotMatch() throws Exception {
     //given, when
     MvcResult mvcResult = mockMvc.perform(
-        get(USER_URL + "/" + TEST_ADMIN_CLASS_OF)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
+      get(USER_URL + "/" + TEST_ADMIN_CLASS_OF)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
     ).andReturn();
 
     //then
@@ -42,8 +42,8 @@ public class MyPageTest extends CommonApiTest {
   public void myPage_Fail_NotFoundUser() throws Exception {
     //given, when
     MvcResult mvcResult = mockMvc.perform(
-        get(USER_URL + "/" + "notFoundUser")
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
+      get(USER_URL + "/" + "notFoundUser")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
     ).andReturn();
 
     //then

--- a/joljak-application/src/test/java/kr/joljak/api/user/MyPageTest.java
+++ b/joljak-application/src/test/java/kr/joljak/api/user/MyPageTest.java
@@ -1,0 +1,27 @@
+package kr.joljak.api.user;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import kr.joljak.api.common.CommonApiTest;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+public class MyPageTest extends CommonApiTest {
+
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void myPage_Success() throws Exception {
+    //given, when
+    MvcResult mvcResult = mockMvc.perform(
+      get(USER_URL + "/" + TEST_USER_CLASS_OF)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+    ).andReturn();
+
+    //then
+    System.out.println(mvcResult.getResponse().getErrorMessage());
+    assertEquals(200, mvcResult.getResponse().getStatus());
+  }
+}

--- a/joljak-application/src/test/java/kr/joljak/api/user/MyPageTest.java
+++ b/joljak-application/src/test/java/kr/joljak/api/user/MyPageTest.java
@@ -34,7 +34,6 @@ public class MyPageTest extends CommonApiTest {
     ).andReturn();
 
     //then
-    System.out.println(mvcResult.getResponse().getErrorMessage());
     assertEquals(403, mvcResult.getResponse().getStatus());
   }
 

--- a/joljak-core/src/main/java/kr/joljak/core/security/UserRole.java
+++ b/joljak-core/src/main/java/kr/joljak/core/security/UserRole.java
@@ -1,5 +1,9 @@
 package kr.joljak.core.security;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+
+@JsonFormat(shape = Shape.OBJECT)
 public enum UserRole {
   ADMIN("ROLE_ADMIN"),
   USER("ROLE_USER");

--- a/joljak-domain-rds/src/main/java/kr/joljak/domain/user/dto/SimpleUser.java
+++ b/joljak-domain-rds/src/main/java/kr/joljak/domain/user/dto/SimpleUser.java
@@ -15,14 +15,19 @@ public class SimpleUser {
   private String classOf;
   private String name;
   private String phoneNumber;
+  private String instagramId;
+  private String kakaoId;
   private List<UserRole> userRoles;
 
   @Builder
-  public SimpleUser(Long id, String classOf, String name, String phoneNumber, List<UserRole> userRoles) {
+  public SimpleUser(Long id, String classOf, String name, String phoneNumber,
+      String instagramId, String kakaoId, List<UserRole> userRoles) {
     this.id = id;
     this.classOf = classOf;
     this.name = name;
     this.phoneNumber = phoneNumber;
+    this.instagramId = instagramId;
+    this.kakaoId = kakaoId;
     this.userRoles = userRoles;
   }
 
@@ -33,6 +38,8 @@ public class SimpleUser {
       .name(user.getName())
       .phoneNumber(user.getPhoneNumber())
       .userRoles(user.getUserRoles())
+      .instagramId(user.getInstagramId())
+      .kakaoId(user.getKakaoId())
       .build();
   }
 }

--- a/joljak-domain-rds/src/main/java/kr/joljak/domain/user/entity/User.java
+++ b/joljak-domain-rds/src/main/java/kr/joljak/domain/user/entity/User.java
@@ -16,6 +16,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 
 @Entity
 @Getter
@@ -37,6 +39,7 @@ public class User extends ExtendEntity {
 
   @Column(nullable = false)
   private String phoneNumber;
+
   private String instagramId;
 
   private String kakaoId;
@@ -49,8 +52,9 @@ public class User extends ExtendEntity {
   private UserProjectRole subProjectRole;
 
   @Column(nullable = false)
-  @ElementCollection
   @Enumerated(value = EnumType.STRING)
+  @ElementCollection
+  @LazyCollection(LazyCollectionOption.FALSE)
   private List<UserRole> userRoles;
 
   @Builder

--- a/joljak-domain-rds/src/main/java/kr/joljak/domain/user/service/UserService.java
+++ b/joljak-domain-rds/src/main/java/kr/joljak/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package kr.joljak.domain.user.service;
 
 import kr.joljak.core.jwt.PermissionException;
 import kr.joljak.core.security.AuthenticationUtils;
+import kr.joljak.domain.user.dto.SimpleUser;
 import kr.joljak.domain.user.entity.User;
 import kr.joljak.domain.user.exception.AlreadyClassOfExistException;
 import kr.joljak.domain.user.exception.UserNotFoundException;
@@ -19,6 +20,13 @@ public class UserService {
   public User signUp(User user) {
     checkDuplicateClassOf(user.getClassOf());
     return userRepository.save(user);
+  }
+
+  @Transactional(readOnly = true)
+  public SimpleUser getMyPage(String classOf) {
+    validExistClassOf(classOf);
+
+    return SimpleUser.of(getUserByClassOf(classOf));
   }
 
   @Transactional(readOnly = true)


### PR DESCRIPTION
## 작업 내용(구체적으로)
- 마이페이지 정보 조회 API 개발
- Enum 리스트를 lazy에서 eager로 변경
- simpleUser에 연락처 추가

## Api
- [x]  마이페이지 정보 조회 API 개발

## Test Result(테스트 결과 이미지 첨부)
<img width="300" alt="스크린샷 2021-03-08 오후 9 58 23" src="https://user-images.githubusercontent.com/50758600/110324514-6cc18a80-8059-11eb-8187-5271ce3900ee.png">

- 마이페이지 _ 성공

- 마이페이지 _ 실패 _ 학번 불일치

- 마이페이지 _ 실패 _ 존재하지 않는 학번