### PR TITLE
비밀번호 업데이트 API

### DIFF
--- a/joljak-application/src/main/java/kr/joljak/api/user/controller/UserController.java
+++ b/joljak-application/src/main/java/kr/joljak/api/user/controller/UserController.java
@@ -51,4 +51,11 @@ public class UserController {
       .user(user)
       .build();
   }
+
+  @ApiOperation("비밀번호 변경 API")
+  @PatchMapping("/{classOf}/password")
+  @ResponseStatus(HttpStatus.OK)
+  public void updatePassword(@PathVariable String classOf, @RequestBody String password) {
+    userService.updatePassword(classOf, password);
+  }
 }

--- a/joljak-application/src/test/java/kr/joljak/api/user/UpdatePassword.java
+++ b/joljak-application/src/test/java/kr/joljak/api/user/UpdatePassword.java
@@ -1,0 +1,67 @@
+package kr.joljak.api.user;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.joljak.api.common.CommonApiTest;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+public class UpdatePassword extends CommonApiTest {
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void updatePassword_Success() throws Exception {
+    // given
+    String password = getOriginalPassword() + nextId++;
+    String request = new ObjectMapper().writeValueAsString(password);
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+      patch(USER_URL + "/" + TEST_USER_CLASS_OF + "/password")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(request)
+    ).andReturn();
+
+    //then
+    assertEquals(200, mvcResult.getResponse().getStatus());
+  }
+
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void updatePassword_Fail_UserDoesNotMatch() throws Exception {
+    // given
+    String password = getOriginalPassword() + nextId++;
+    String request = new ObjectMapper().writeValueAsString(password);
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+      patch(USER_URL + "/" + TEST_ADMIN_CLASS_OF + "/password")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(request)
+    ).andReturn();
+
+    //then
+    assertEquals(403, mvcResult.getResponse().getStatus());
+  }
+
+  @Test
+  @WithMockUser(username = "notFoundUser", roles = "USER")
+  public void updatePassword_Fail_UserNotFoundException() throws Exception {
+    // given
+    String password = getOriginalPassword() + nextId++;
+    String request = new ObjectMapper().writeValueAsString(password);
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(
+        patch(USER_URL + "/" + "notFoundUser" + "/password")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(request)
+    ).andReturn();
+
+    //then
+    assertEquals(404, mvcResult.getResponse().getStatus());
+  }
+}

--- a/joljak-domain-rds/src/main/java/kr/joljak/domain/user/service/UserService.java
+++ b/joljak-domain-rds/src/main/java/kr/joljak/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import kr.joljak.domain.user.exception.AlreadyClassOfExistException;
 import kr.joljak.domain.user.exception.UserNotFoundException;
 import kr.joljak.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,13 @@ public class UserService {
     validExistClassOf(classOf);
 
     return SimpleUser.of(getUserByClassOf(classOf));
+  }
+
+  @Transactional
+  public void updatePassword(String classOf, String password) {
+    validAuthenticationClassOf(classOf);
+    User user = getUserByClassOf(classOf);
+    user.setPassword(new BCryptPasswordEncoder().encode(password));
   }
 
   @Transactional(readOnly = true)
@@ -65,7 +73,7 @@ public class UserService {
   public void updateKakaoId(String classOf, String kakaoId) {
     validExistClassOf(classOf);
     User user = userRepository.findByClassOf(classOf)
-        .orElseThrow(UserNotFoundException::new);
+      .orElseThrow(UserNotFoundException::new);
 
     user.setKakaoId(kakaoId);
   }

--- a/joljak-domain-rds/src/test/java/kr/joljak/domain/user/UserServiceTest.java
+++ b/joljak-domain-rds/src/test/java/kr/joljak/domain/user/UserServiceTest.java
@@ -1,6 +1,7 @@
 package kr.joljak.domain.user;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import kr.joljak.core.security.UserRole;
 import kr.joljak.domain.common.CommonDomainTest;
@@ -123,5 +124,21 @@ public class UserServiceTest extends CommonDomainTest {
 
     // then
     assertEquals(user.getKakaoId(), changeKakaoId);
+  }
+
+  @Test
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void updatePassword_success() {
+    // given
+    User user = userService.getUserByClassOf(TEST_USER_CLASS_OF);
+    String originalHashedPassword = user.getPassword();
+    String afterPassword = "1234567890";
+
+    // when
+    userService.updatePassword(user.getClassOf(), afterPassword);
+    user = userService.getUserByClassOf(user.getClassOf());
+
+    // then
+    assertNotEquals(originalHashedPassword, user.getPassword());
   }
 }

--- a/joljak-domain-rds/src/test/java/kr/joljak/domain/user/UserServiceTest.java
+++ b/joljak-domain-rds/src/test/java/kr/joljak/domain/user/UserServiceTest.java
@@ -3,6 +3,7 @@ package kr.joljak.domain.user;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
+import kr.joljak.core.jwt.PermissionException;
 import kr.joljak.core.security.UserRole;
 import kr.joljak.domain.common.CommonDomainTest;
 import kr.joljak.domain.user.entity.User;
@@ -83,7 +84,7 @@ public class UserServiceTest extends CommonDomainTest {
 
   @Test
   @WithMockUser(username = "testUser1", roles = "USER")
-  public void updatePhoneNumber_success() {
+  public void updatePhoneNumber_Success() {
     // given
     User user = userService.getUserByClassOf(TEST_USER_CLASS_OF);
     String changePhoneNumber = user.getPhoneNumber() + nextId++;
@@ -98,7 +99,7 @@ public class UserServiceTest extends CommonDomainTest {
 
   @Test
   @WithMockUser(username = "testUser1", roles = "USER")
-  public void updateInstagramId_success() {
+  public void updateInstagramId_Success() {
     // given
     User user = userService.getUserByClassOf(TEST_USER_CLASS_OF);
     String changeInstagramId = "changeInstagramId" + nextId++;
@@ -113,7 +114,7 @@ public class UserServiceTest extends CommonDomainTest {
 
   @Test
   @WithMockUser(username = "testUser1", roles = "USER")
-  public void updateKakaoId_success() {
+  public void updateKakaoId_Success() {
     // given
     User user = userService.getUserByClassOf(TEST_USER_CLASS_OF);
     String changeKakaoId = "changeKakaoId" + nextId++;
@@ -141,4 +142,37 @@ public class UserServiceTest extends CommonDomainTest {
     // then
     assertNotEquals(originalHashedPassword, user.getPassword());
   }
+
+  @Test(expected = UserNotFoundException.class)
+  @WithMockUser(username = "notFoundUser", roles = "USER")
+  public void updatePassword_Fail_UserNotFoundException() {
+    // given
+    User user = userService.getUserByClassOf("notFoundUser");
+    String originalHashedPassword = user.getPassword();
+    String afterPassword = "1234567890";
+
+    // when
+    userService.updatePassword(user.getClassOf(), afterPassword);
+    user = userService.getUserByClassOf(user.getClassOf());
+
+    // then
+    assertNotEquals(originalHashedPassword, user.getPassword());
+  }
+
+  @Test(expected = PermissionException.class)
+  @WithMockUser(username = "testUser1", roles = "USER")
+  public void updatePassword_Fail_PermissionException() {
+    // given
+    User user = userService.getUserByClassOf(TEST_ADMIN_CLASS_OF);
+    String originalHashedPassword = user.getPassword();
+    String afterPassword = "1234567890";
+
+    // when
+    userService.updatePassword(user.getClassOf(), afterPassword);
+    user = userService.getUserByClassOf(user.getClassOf());
+
+    // then
+    assertNotEquals(originalHashedPassword, user.getPassword());
+  }
+
 }


### PR DESCRIPTION
## 작업 내용(구체적으로)
- 비밀번호 업데이트 API 개발

## Api
- [x] 비밀번호 업데이트 API 개발

## Test Result(테스트 결과 이미지 첨부)
- controller(Application)
![스크린샷 2021-03-10 오전 12 53 39](https://user-images.githubusercontent.com/50758600/110499186-55f36480-813b-11eb-9c4d-fedbd90b6223.png)
  - 비밀번호 업데이트 _ 성공
  - 비밀번호 업데이트 _ 실패 _ 유저 권한 없음
  - 비밀번호 업데이트 _ 실패 _ 유저 없음

- service(Domain)
  - 비밀번호 업데이트 _ 성공
    ![스크린샷 2021-03-10 오전 12 53 15](https://user-images.githubusercontent.com/50758600/110499206-5be94580-813b-11eb-9507-bd33055966de.png)

  - 비밀번호 업데이트 _ 실패 _ 권한 없음
    <img width="391" alt="스크린샷 2021-03-10 오후 8 45 24" src="https://user-images.githubusercontent.com/50758600/110624671-e1273580-81e1-11eb-9f1d-a973104655c4.png">

  - 비밀번호 업데이트 _ 실패 _ 유정 정보 없음
    <img width="398" alt="스크린샷 2021-03-10 오후 8 42 30" src="https://user-images.githubusercontent.com/50758600/110624664-dd93ae80-81e1-11eb-8f8a-7bbf99dc5f41.png">

도메인 테스트의 경우 실제 비밀번호가 정상적으로 바뀌는지 검증이 필요하기에 성공 케이스만 테스트 코드 작성.

